### PR TITLE
Remove estargz support

### DIFF
--- a/cmd/gopack/main.go
+++ b/cmd/gopack/main.go
@@ -34,7 +34,6 @@ var (
 	compression int
 	concurrency int
 	daemon      string
-	estargz     bool
 	labels      []string
 	ldflags     string
 	mod         string
@@ -56,7 +55,6 @@ func init() {
 	runCmd.Flags().IntVar(&compression, "compression", -1, "gzip compression level of image layers")
 	runCmd.Flags().IntVarP(&concurrency, "concurrency", "c", 0, "number of concurrent builds (default GOMAXPROCS)")
 	runCmd.Flags().StringVarP(&daemon, "daemon", "d", "", "push image to local daemon (e.g. docker)")
-	runCmd.Flags().BoolVar(&estargz, "estargz", false, "enable estargz on image")
 	runCmd.Flags().StringSliceVarP(&labels, "label", "l", nil, "labels to include in image")
 	runCmd.Flags().StringVar(&ldflags, "ldflags", "", "ldflags used during Go compilation")
 	runCmd.Flags().StringVar(&mod, "mod", "", "mod flag used during Go compilation")
@@ -82,7 +80,6 @@ var runCmd = &cobra.Command{
 		options := []gopack.RunOption{
 			gopack.WithCGOEnabled(cgoEnabled),
 			gopack.WithTrimpath(trimpath),
-			gopack.WithEStargz(estargz),
 		}
 
 		if concurrency > 0 {

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,6 @@ module github.com/ryanfowler/gopack
 go 1.20
 
 require (
-	github.com/containerd/stargz-snapshotter/estargz v0.14.3
 	github.com/google/go-containerregistry v0.14.0
 	github.com/spf13/cobra v1.7.0
 	golang.org/x/sync v0.2.0
@@ -14,6 +13,7 @@ require (
 	cloud.google.com/go/compute v1.18.0 // indirect
 	cloud.google.com/go/compute/metadata v0.2.3 // indirect
 	github.com/Microsoft/go-winio v0.6.0 // indirect
+	github.com/containerd/stargz-snapshotter/estargz v0.14.3 // indirect
 	github.com/docker/cli v23.0.1+incompatible // indirect
 	github.com/docker/distribution v2.8.1+incompatible // indirect
 	github.com/docker/docker v23.0.3+incompatible // indirect

--- a/internal/oci/build.go
+++ b/internal/oci/build.go
@@ -23,7 +23,6 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/containerd/stargz-snapshotter/estargz"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/tarball"
@@ -45,12 +44,6 @@ func BuildImage(ctx context.Context, goBinPath string, base v1.Image, options ..
 	layerOpts := []tarball.LayerOption{
 		tarball.WithCompressedCaching,
 		tarball.WithCompressionLevel(opts.gzipCompressionLevel),
-	}
-	if opts.estargzEnabled {
-		layerOpts = append(layerOpts,
-			tarball.WithEstargz,
-			tarball.WithEstargzOptions(
-				estargz.WithPrioritizedFiles([]string{entrypoint})))
 	}
 
 	layer, err := tarball.LayerFromOpener(func() (io.ReadCloser, error) {

--- a/internal/oci/oci.go
+++ b/internal/oci/oci.go
@@ -30,12 +30,6 @@ func WithCompressionLevel(v int) BuildOption {
 	}
 }
 
-func WithEStargz(v bool) BuildOption {
-	return func(bo *buildOptions) {
-		bo.estargzEnabled = v
-	}
-}
-
 func WithLabels(v map[string]string) BuildOption {
 	return func(bo *buildOptions) {
 		bo.labels = v
@@ -43,14 +37,12 @@ func WithLabels(v map[string]string) BuildOption {
 }
 
 type buildOptions struct {
-	estargzEnabled       bool
 	gzipCompressionLevel int
 	labels               map[string]string
 }
 
 func defaultBuildOptions() *buildOptions {
 	return &buildOptions{
-		estargzEnabled:       false,
 		gzipCompressionLevel: gzip.DefaultCompression,
 		labels:               nil,
 	}

--- a/pkg/gopack/options.go
+++ b/pkg/gopack/options.go
@@ -84,12 +84,6 @@ func WithDaemon(v string) RunOption {
 	}
 }
 
-func WithEStargz(v bool) RunOption {
-	return func(ro *runOptions) {
-		ro.estargzEnabled = v
-	}
-}
-
 func WithLabels(v map[string]string) RunOption {
 	return func(ro *runOptions) {
 		ro.labels = v
@@ -130,7 +124,6 @@ type runOptions struct {
 	base             string
 	compressionLevel int
 	daemon           string
-	estargzEnabled   bool
 	labels           map[string]string
 	platforms        []string
 	repository       string
@@ -151,7 +144,6 @@ func defaultRunOptions() *runOptions {
 		base:             "gcr.io/distroless/static:nonroot",
 		compressionLevel: gzip.DefaultCompression,
 		daemon:           "",
-		estargzEnabled:   false,
 		labels:           nil,
 		platforms:        []string{types.DefaultPlatform.String()},
 		repository:       "",

--- a/pkg/gopack/run.go
+++ b/pkg/gopack/run.go
@@ -149,7 +149,6 @@ func build(ctx context.Context, goBuilder *golang.GoBuilder, binName string, p t
 
 	buildOptions := []oci.BuildOption{
 		oci.WithCompressionLevel(opts.compressionLevel),
-		oci.WithEStargz(opts.estargzEnabled),
 		oci.WithLabels(opts.labels),
 	}
 	return oci.BuildImage(ctx, goBinPath, img, buildOptions...)


### PR DESCRIPTION
estargz is removed due to the deprecation in the upstream go-containerregistry dependency.