### PR TITLE
internal/oci: Strip leading slashes from tar header

### DIFF
--- a/internal/oci/build.go
+++ b/internal/oci/build.go
@@ -22,6 +22,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
@@ -106,7 +107,7 @@ func tarGoBin(goBinPath, entrypoint string) ([]byte, error) {
 
 	err = tw.WriteHeader(&tar.Header{
 		Mode:     0555,
-		Name:     entrypoint,
+		Name:     strings.TrimPrefix(entrypoint, "/"),
 		Size:     stat.Size(),
 		Typeflag: tar.TypeReg,
 	})


### PR DESCRIPTION
When adding the tar header for the built binary, the leading slashes in the path should be stripped since members within a tar archive should have a relative path. This way, when the tar archive is unpacked in the current directory, or in a different directory when invoked with `tar -C`, the structure within the archive is mirrored outside of the archive.

Prior to this commit, if you built an image with gopack, attempted to fetch the individual layer blob from a registry, and print the layer's contents, you would see an error like this:

	tar: Removing leading `/' from member names
	/app/gopack-test

While GNU tar(1) will strip the leading slashes from member names, it would likely be better to remove the leading slash from the member name entirely when the header is written.

After using gopack with this patch applied, attempting to list the archive members from the retrieved layer/blob, the tar warning goes away.