### PR TITLE
Upgrade Go version to 1.24.5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: ["1.24.1"]
+        go: ["1.24.5"]
     steps:
       - uses: actions/checkout@v4
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     types: [published]
 
 env:
-  GO_VERSION: "1.24.1"
+  GO_VERSION: "1.24.5"
 
 jobs:
   release:

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/ryanfowler/gopack
 
-go 1.24.1
+go 1.24.5
 
 require (
 	github.com/google/go-containerregistry v0.20.6


### PR DESCRIPTION
## Summary
• Updates Go version from 1.24.1 to 1.24.5 across all configuration files
• Ensures consistency between go.mod and GitHub Actions workflows
• Maintains compatibility with existing dependencies

## Test plan
- [ ] Verify CI workflow runs successfully with Go 1.24.5
- [ ] Confirm all existing tests pass
- [ ] Validate release workflow builds correctly

🤖 Generated with [Claude Code](https://claude.ai/code)