### PR TITLE
Add publish, build, and load aliases for gopack

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,45 +18,61 @@ Go 1.18+ is required.
 
 ### Usage
 
-Use the `gopack run` command to build and publish an image. Although all flags
-are optional, some notable flags are:
+Use `gopack publish` to build and publish an image. `gopack run` is still
+supported for compatibility. Although most flags are optional, some notable
+flags are:
 - `--base`: image to use as the base (default: `gcr.io/distroless/static:nonroot`)
 - `--repository`: repository to push the final image to (default: Go binary name)
 - `--platform`: platform(s) to build the image(s) for (default: `linux/amd64`)
 - `--tag`: tag(s) to push the image with (default: `latest`)
-- `--daemon`: push the final image to a local daemon, instead of the remote repository (e.g. `docker`)
+- `--output`: output target for `gopack build` (for example: `oci:./image.tar`)
+- `--load`: load the final image to a local daemon
+- `--daemon`: local daemon backend (currently: `docker`)
 
 #### Using a custom base image
 
 ```sh
-gopack run ./cmd/gopack -b myimage:tag
+gopack publish ./cmd/gopack -b myimage:tag
 ```
 
-#### Pushing to a specific remote respository
+#### Pushing to a specific remote repository
 
 ```sh
-gopack run ./cmd/gopack -r ghcr.io/OWNER/gopack
+gopack publish ./cmd/gopack -r ghcr.io/OWNER/gopack
 ```
 
 #### Building for multiple platforms
 
 ```sh
-gopack run ./cmd/gopack -p linux/amd64 -p linux/arm64
+gopack publish ./cmd/gopack -p linux/amd64 -p linux/arm64
 ```
 
 #### Specifying tags
 
 ```sh
-gopack run ./cmd/gopack -t latest -t 12345678
+gopack publish ./cmd/gopack -t latest -t 12345678
+```
+
+#### Build to an OCI archive
+
+```sh
+gopack build ./cmd/gopack --output oci:./image.tar
 ```
 
 #### Push to a local daemon
 
 ```sh
+gopack load ./cmd/gopack --daemon docker
+```
+
+The older daemon form remains valid:
+
+```sh
 gopack run ./cmd/gopack --daemon docker
 ```
 
-_Please run `gopack run -h` for more information about the available options._
+_Please run `gopack publish -h`, `gopack build -h`, or `gopack load -h` for more
+information about the available options._
 
 ### License
 

--- a/cmd/gopack/main.go
+++ b/cmd/gopack/main.go
@@ -30,7 +30,18 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var (
+const dockerDaemon = "docker"
+
+type commandMode int
+
+const (
+	modeRun commandMode = iota
+	modePublish
+	modeBuild
+	modeLoad
+)
+
+type cliOptions struct {
 	base        string
 	cgoEnabled  bool
 	compression int
@@ -38,111 +49,226 @@ var (
 	daemon      string
 	labels      []string
 	ldflags     string
+	load        bool
 	mod         string
+	output      string
 	platforms   []string
 	repository  string
 	tags        []string
 	trimpath    bool
-)
+}
 
-func init() {
+var rootCmd = newRootCmd()
+
+func newRootCmd() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:          "gopack",
+		SilenceUsage: true,
+	}
 	if info, ok := debug.ReadBuildInfo(); ok {
-		rootCmd.Version = info.Main.Version
+		cmd.Version = info.Main.Version
 	}
 
-	rootCmd.AddCommand(runCmd)
-
-	runCmd.Flags().StringVarP(&base, "base", "b", "gcr.io/distroless/static:nonroot", "repository to use as the base image")
-	runCmd.Flags().BoolVar(&cgoEnabled, "cgo", false, "enable CGO during Go compilation")
-	runCmd.Flags().IntVar(&compression, "compression", -1, "gzip compression level of image layers")
-	runCmd.Flags().IntVarP(&concurrency, "concurrency", "c", 0, "number of concurrent builds (default GOMAXPROCS)")
-	runCmd.Flags().StringVarP(&daemon, "daemon", "d", "", "push image to local daemon (e.g. docker)")
-	runCmd.Flags().StringSliceVarP(&labels, "label", "l", nil, "labels to include in image")
-	runCmd.Flags().StringVar(&ldflags, "ldflags", "", "ldflags used during Go compilation")
-	runCmd.Flags().StringVar(&mod, "mod", "", "mod flag used during Go compilation")
-	runCmd.Flags().StringSliceVarP(&platforms, "platform", "p", []string{types.DefaultPlatform.String()}, "platforms to build for")
-	runCmd.Flags().StringVarP(&repository, "repository", "r", "", "repository to push image to")
-	runCmd.Flags().StringSliceVarP(&tags, "tag", "t", []string{oci.DefaultTag}, "tags to push image with")
-	runCmd.Flags().BoolVar(&trimpath, "trimpath", true, "enable trimpath during Go compilation")
+	cmd.AddCommand(
+		newRunCommand(),
+		newPublishCommand(),
+		newBuildCommand(),
+		newLoadCommand(),
+	)
+	return cmd
 }
 
-var rootCmd = &cobra.Command{
-	Use:          "gopack",
-	SilenceUsage: true,
+func newRunCommand() *cobra.Command {
+	opts := defaultCLIOptions()
+	cmd := newPackageCommand(modeRun, opts)
+	cmd.Use = "run [package]"
+	cmd.Short = "Build and publish or load a Go binary as a minimal OCI image"
+	addCommonFlags(cmd, opts)
+	addLoadFlags(cmd, opts)
+	addDaemonFlag(cmd, opts, "")
+	return cmd
 }
 
-var runCmd = &cobra.Command{
-	Use:   "run [package]",
-	Args:  cobra.RangeArgs(0, 1),
-	Short: "Build and publish a Go binary as a minimal OCI image",
-	RunE: func(cmd *cobra.Command, args []string) error {
-		ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-		defer stop()
+func newPublishCommand() *cobra.Command {
+	opts := defaultCLIOptions()
+	cmd := newPackageCommand(modePublish, opts)
+	cmd.Use = "publish [package]"
+	cmd.Short = "Build and publish a Go binary as a minimal OCI image"
+	addCommonFlags(cmd, opts)
+	return cmd
+}
 
-		options := []gopack.RunOption{
-			gopack.WithCGOEnabled(cgoEnabled),
-			gopack.WithTrimpath(trimpath),
-		}
+func newBuildCommand() *cobra.Command {
+	opts := defaultCLIOptions()
+	cmd := newPackageCommand(modeBuild, opts)
+	cmd.Use = "build [package]"
+	cmd.Short = "Build a Go binary as a minimal OCI image archive"
+	addCommonFlags(cmd, opts)
+	cmd.Flags().StringVarP(&opts.output, "output", "o", "", "output target (e.g. oci:./image.tar)")
+	return cmd
+}
 
-		if concurrency > 0 {
-			options = append(options, gopack.WithConcurrency(concurrency))
-		}
-		if ldflags != "" {
-			options = append(options, gopack.WithLDFlags(ldflags))
-		}
-		if len(args) == 1 {
-			options = append(options, gopack.WithMainPath(args[0]))
-		}
-		if mod != "" {
-			options = append(options, gopack.WithModFlag(mod))
-		}
-		if base != "" {
-			options = append(options, gopack.WithBase(base))
-		}
-		if compression >= 0 {
-			options = append(options, gopack.WithCompressionLevel(compression))
-		}
-		if daemon != "" {
-			options = append(options, gopack.WithDaemon(daemon))
-		}
-		if len(labels) > 0 {
-			m := make(map[string]string, len(labels))
-			for _, label := range labels {
-				var key, val string
-				idx := strings.Index(label, "=")
-				if idx >= 0 {
-					key = label[:idx]
-					val = label[idx+1:]
-				} else {
-					key = label
-				}
-				if key == "" {
-					return fmt.Errorf("invalid label %q: empty key", label)
-				}
-				if !isValidLabelKey(key) {
-					return fmt.Errorf("invalid label key %q", key)
-				}
-				m[key] = val
+func newLoadCommand() *cobra.Command {
+	opts := defaultCLIOptions()
+	cmd := newPackageCommand(modeLoad, opts)
+	cmd.Use = "load [package]"
+	cmd.Short = "Build and load a Go binary image into a local daemon"
+	addCommonFlags(cmd, opts)
+	addDaemonFlag(cmd, opts, dockerDaemon)
+	return cmd
+}
+
+func newPackageCommand(mode commandMode, opts *cliOptions) *cobra.Command {
+	return &cobra.Command{
+		Args: cobra.RangeArgs(0, 1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if err := validateCommandOptions(mode, opts); err != nil {
+				return err
 			}
-			options = append(options, gopack.WithLabels(m))
-		}
-		if len(platforms) > 0 {
-			options = append(options, gopack.WithPlatforms(platforms))
-		}
-		if repository != "" {
-			options = append(options, gopack.WithRepository(repository))
-		}
-		if len(tags) > 0 {
-			options = append(options, gopack.WithTags(tags))
-		}
 
-		out, err := gopack.Run(ctx, options...)
-		if err != nil {
-			return err
+			ctx, stop := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+			defer stop()
+
+			options, err := buildRunOptions(mode, opts, args)
+			if err != nil {
+				return err
+			}
+
+			out, err := gopack.Run(ctx, options...)
+			if err != nil {
+				return err
+			}
+			fmt.Fprintln(cmd.OutOrStdout(), out)
+			return nil
+		},
+	}
+}
+
+func defaultCLIOptions() *cliOptions {
+	return &cliOptions{
+		base:        "gcr.io/distroless/static:nonroot",
+		compression: -1,
+		platforms:   []string{types.DefaultPlatform.String()},
+		tags:        []string{oci.DefaultTag},
+		trimpath:    true,
+	}
+}
+
+func addCommonFlags(cmd *cobra.Command, opts *cliOptions) {
+	cmd.Flags().StringVarP(&opts.base, "base", "b", opts.base, "repository to use as the base image")
+	cmd.Flags().BoolVar(&opts.cgoEnabled, "cgo", opts.cgoEnabled, "enable CGO during Go compilation")
+	cmd.Flags().IntVar(&opts.compression, "compression", opts.compression, "gzip compression level of image layers")
+	cmd.Flags().IntVarP(&opts.concurrency, "concurrency", "c", opts.concurrency, "number of concurrent builds (default GOMAXPROCS)")
+	cmd.Flags().StringSliceVarP(&opts.labels, "label", "l", opts.labels, "labels to include in image")
+	cmd.Flags().StringVar(&opts.ldflags, "ldflags", opts.ldflags, "ldflags used during Go compilation")
+	cmd.Flags().StringVar(&opts.mod, "mod", opts.mod, "mod flag used during Go compilation")
+	cmd.Flags().StringSliceVarP(&opts.platforms, "platform", "p", opts.platforms, "platforms to build for")
+	cmd.Flags().StringVarP(&opts.repository, "repository", "r", opts.repository, "repository to name or push image as")
+	cmd.Flags().StringSliceVarP(&opts.tags, "tag", "t", opts.tags, "tags to apply to the image")
+	cmd.Flags().BoolVar(&opts.trimpath, "trimpath", opts.trimpath, "enable trimpath during Go compilation")
+}
+
+func addLoadFlags(cmd *cobra.Command, opts *cliOptions) {
+	cmd.Flags().BoolVar(&opts.load, "load", false, "load image to a local daemon")
+}
+
+func addDaemonFlag(cmd *cobra.Command, opts *cliOptions, daemonDefault string) {
+	opts.daemon = daemonDefault
+	cmd.Flags().StringVarP(&opts.daemon, "daemon", "d", daemonDefault, "local daemon backend (supported: docker)")
+}
+
+func validateCommandOptions(mode commandMode, opts *cliOptions) error {
+	switch mode {
+	case modeBuild:
+		if opts.output == "" {
+			return fmt.Errorf("build requires --output")
 		}
-		fmt.Println(out)
-		return nil
-	},
+	case modeLoad:
+		opts.load = true
+	case modeRun:
+		if opts.output != "" {
+			return fmt.Errorf("run does not support --output; use build")
+		}
+	}
+	return nil
+}
+
+func buildRunOptions(mode commandMode, opts *cliOptions, args []string) ([]gopack.RunOption, error) {
+	options := []gopack.RunOption{
+		gopack.WithCGOEnabled(opts.cgoEnabled),
+		gopack.WithTrimpath(opts.trimpath),
+	}
+
+	if opts.concurrency > 0 {
+		options = append(options, gopack.WithConcurrency(opts.concurrency))
+	}
+	if opts.ldflags != "" {
+		options = append(options, gopack.WithLDFlags(opts.ldflags))
+	}
+	if len(args) == 1 {
+		options = append(options, gopack.WithMainPath(args[0]))
+	}
+	if opts.mod != "" {
+		options = append(options, gopack.WithModFlag(opts.mod))
+	}
+	if opts.base != "" {
+		options = append(options, gopack.WithBase(opts.base))
+	}
+	if opts.compression >= 0 {
+		options = append(options, gopack.WithCompressionLevel(opts.compression))
+	}
+	if opts.daemon != "" {
+		options = append(options, gopack.WithDaemon(opts.daemon))
+	}
+	if opts.load {
+		options = append(options, gopack.WithLoad(true))
+	}
+	if opts.output != "" {
+		options = append(options, gopack.WithOutput(opts.output))
+	}
+	if len(opts.labels) > 0 {
+		m, err := parseLabels(opts.labels)
+		if err != nil {
+			return nil, err
+		}
+		options = append(options, gopack.WithLabels(m))
+	}
+	if len(opts.platforms) > 0 {
+		options = append(options, gopack.WithPlatforms(opts.platforms))
+	}
+	if opts.repository != "" {
+		options = append(options, gopack.WithRepository(opts.repository))
+	}
+	if len(opts.tags) > 0 {
+		options = append(options, gopack.WithTags(opts.tags))
+	}
+	if mode == modeLoad {
+		options = append(options, gopack.WithLoad(true))
+	}
+
+	return options, nil
+}
+
+func parseLabels(labels []string) (map[string]string, error) {
+	m := make(map[string]string, len(labels))
+	for _, label := range labels {
+		var key, val string
+		idx := strings.Index(label, "=")
+		if idx >= 0 {
+			key = label[:idx]
+			val = label[idx+1:]
+		} else {
+			key = label
+		}
+		if key == "" {
+			return nil, fmt.Errorf("invalid label %q: empty key", label)
+		}
+		if !isValidLabelKey(key) {
+			return nil, fmt.Errorf("invalid label key %q", key)
+		}
+		m[key] = val
+	}
+	return m, nil
 }
 
 func isValidLabelKey(key string) bool {

--- a/cmd/gopack/main_test.go
+++ b/cmd/gopack/main_test.go
@@ -14,7 +14,41 @@
 
 package main
 
-import "testing"
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+func TestBuildRequiresOutput(t *testing.T) {
+	_, err := executeCommand("build", "/path/that/does/not/exist")
+	if err == nil {
+		t.Fatal("command error = nil, want missing output error")
+	}
+	if !strings.Contains(err.Error(), "build requires --output") {
+		t.Fatalf("command error = %q, want missing output error", err)
+	}
+}
+
+func TestLoadRejectsUnsupportedDaemonBeforeOtherWork(t *testing.T) {
+	_, err := executeCommand("load", "/path/that/does/not/exist", "--daemon", "podman")
+	if err == nil {
+		t.Fatal("command error = nil, want unsupported daemon error")
+	}
+	if !strings.Contains(err.Error(), `unsupported daemon "podman"`) {
+		t.Fatalf("command error = %q, want unsupported daemon error", err)
+	}
+}
+
+func executeCommand(args ...string) (string, error) {
+	cmd := newRootCmd()
+	buf := new(bytes.Buffer)
+	cmd.SetOut(buf)
+	cmd.SetErr(buf)
+	cmd.SetArgs(args)
+	err := cmd.Execute()
+	return buf.String(), err
+}
 
 func TestIsValidLabelKey(t *testing.T) {
 	tests := []struct {

--- a/internal/gopack/options.go
+++ b/internal/gopack/options.go
@@ -84,6 +84,18 @@ func WithDaemon(v string) RunOption {
 	}
 }
 
+func WithLoad(v bool) RunOption {
+	return func(ro *runOptions) {
+		ro.load = v
+	}
+}
+
+func WithOutput(v string) RunOption {
+	return func(ro *runOptions) {
+		ro.output = v
+	}
+}
+
 func WithLabels(v map[string]string) RunOption {
 	return func(ro *runOptions) {
 		ro.labels = v
@@ -124,6 +136,8 @@ type runOptions struct {
 	base             string
 	compressionLevel int
 	daemon           string
+	load             bool
+	output           string
 	labels           map[string]string
 	platforms        []string
 	repository       string
@@ -144,6 +158,8 @@ func defaultRunOptions() *runOptions {
 		base:             "gcr.io/distroless/static:nonroot",
 		compressionLevel: gzip.DefaultCompression,
 		daemon:           "",
+		load:             false,
+		output:           "",
 		labels:           nil,
 		platforms:        []string{types.DefaultPlatform.String()},
 		repository:       "",

--- a/internal/gopack/run.go
+++ b/internal/gopack/run.go
@@ -15,11 +15,15 @@
 package gopack
 
 import (
+	"archive/tar"
 	"context"
 	"errors"
 	"fmt"
+	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"sync"
 
@@ -30,6 +34,7 @@ import (
 	"github.com/google/go-containerregistry/pkg/name"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
 	"github.com/google/go-containerregistry/pkg/v1/empty"
+	"github.com/google/go-containerregistry/pkg/v1/layout"
 	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/remote"
 	crtypes "github.com/google/go-containerregistry/pkg/v1/types"
@@ -39,13 +44,17 @@ import (
 var ErrNoMatchingImage = errors.New("no matching image")
 
 const dockerDaemon = "docker"
+const ociOutputPrefix = "oci:"
 
 func Run(ctx context.Context, options ...RunOption) (string, error) {
 	opts := defaultRunOptions()
 	for _, o := range options {
 		o(opts)
 	}
-	if err := validateDaemon(opts.daemon); err != nil {
+	if opts.load && opts.daemon == "" {
+		opts.daemon = dockerDaemon
+	}
+	if err := validateDestination(opts); err != nil {
 		return "", err
 	}
 	platforms, err := parsePlatforms(opts.platforms)
@@ -85,6 +94,21 @@ func Run(ctx context.Context, options ...RunOption) (string, error) {
 	}
 
 	return output, nil
+}
+
+func validateDestination(opts *runOptions) error {
+	if err := validateDaemon(opts.daemon); err != nil {
+		return err
+	}
+	if opts.output != "" {
+		if opts.daemon != "" || opts.load {
+			return errors.New("cannot use output with daemon load")
+		}
+		if _, err := parseOutput(opts.output); err != nil {
+			return err
+		}
+	}
+	return nil
 }
 
 func validateDaemon(daemon string) error {
@@ -177,6 +201,17 @@ func build(ctx context.Context, goBuilder *golang.GoBuilder, binName string, p t
 }
 
 func push(ctx context.Context, imgs map[types.Platform]v1.Image, mt crtypes.MediaType, opts *runOptions) (string, error) {
+	if opts.output != "" {
+		path, err := parseOutput(opts.output)
+		if err != nil {
+			return "", err
+		}
+		if err := writeOCIArchive(path, imgs); err != nil {
+			return "", err
+		}
+		return path, nil
+	}
+
 	if opts.daemon == dockerDaemon {
 		if len(imgs) != 1 {
 			return "", errors.New("push: can only push a single image to docker")
@@ -209,10 +244,52 @@ func push(ctx context.Context, imgs map[types.Platform]v1.Image, mt crtypes.Medi
 		return chooseOutput(opts.repository, img, opts.tags)
 	}
 
+	index := makeImageIndex(imgs, mt)
+	err = oci.Push(ctx, repo, index, oci.WithTags(opts.tags), oci.WithLogger(opts.logger))
+	if err != nil {
+		return "", err
+	}
+	return chooseOutput(opts.repository, index, opts.tags)
+}
+
+func parseOutput(output string) (string, error) {
+	path := strings.TrimPrefix(output, ociOutputPrefix)
+	if path == output || path == "" {
+		return "", fmt.Errorf("unsupported output %q (supported: oci:<path>)", output)
+	}
+	return path, nil
+}
+
+func writeOCIArchive(path string, imgs map[types.Platform]v1.Image) error {
+	dir, err := os.MkdirTemp("", "gopack-oci-")
+	if err != nil {
+		return err
+	}
+	defer os.RemoveAll(dir)
+
+	if _, err := layout.Write(dir, makeImageIndex(imgs, crtypes.OCIImageIndex)); err != nil {
+		return fmt.Errorf("writing OCI layout: %w", err)
+	}
+	return tarDirectory(path, dir)
+}
+
+func makeImageIndex(imgs map[types.Platform]v1.Image, mt crtypes.MediaType) v1.ImageIndex {
+	if !mt.IsIndex() {
+		mt = crtypes.OCIImageIndex
+	}
+
+	platforms := make([]types.Platform, 0, len(imgs))
+	for platform := range imgs {
+		platforms = append(platforms, platform)
+	}
+	sort.Slice(platforms, func(i, j int) bool {
+		return platforms[i].String() < platforms[j].String()
+	})
+
 	addendums := make([]mutate.IndexAddendum, 0, len(imgs))
-	for platform, img := range imgs {
+	for _, platform := range platforms {
 		addendums = append(addendums, mutate.IndexAddendum{
-			Add: img,
+			Add: imgs[platform],
 			Descriptor: v1.Descriptor{
 				Platform: &v1.Platform{
 					Architecture: platform.Arch(),
@@ -224,13 +301,70 @@ func push(ctx context.Context, imgs map[types.Platform]v1.Image, mt crtypes.Medi
 	}
 
 	base := mutate.IndexMediaType(empty.Index, mt)
-	index := mutate.AppendManifests(base, addendums...)
+	return mutate.AppendManifests(base, addendums...)
+}
 
-	err = oci.Push(ctx, repo, index, oci.WithTags(opts.tags), oci.WithLogger(opts.logger))
+func tarDirectory(path string, dir string) (err error) {
+	out, err := os.Create(path)
 	if err != nil {
-		return "", err
+		return err
 	}
-	return chooseOutput(opts.repository, index, opts.tags)
+	defer func() {
+		if closeErr := out.Close(); err == nil {
+			err = closeErr
+		}
+	}()
+
+	tw := tar.NewWriter(out)
+	defer func() {
+		if closeErr := tw.Close(); err == nil {
+			err = closeErr
+		}
+	}()
+
+	err = filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(dir, path)
+		if err != nil {
+			return err
+		}
+		if rel == "." {
+			return nil
+		}
+
+		info, err := d.Info()
+		if err != nil {
+			return err
+		}
+		hdr, err := tar.FileInfoHeader(info, "")
+		if err != nil {
+			return err
+		}
+		hdr.Name = filepath.ToSlash(rel)
+		if d.IsDir() {
+			hdr.Name += "/"
+		}
+		if err := tw.WriteHeader(hdr); err != nil {
+			return err
+		}
+		if !info.Mode().IsRegular() {
+			return nil
+		}
+
+		in, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		_, copyErr := io.Copy(tw, in)
+		closeErr := in.Close()
+		if copyErr != nil {
+			return copyErr
+		}
+		return closeErr
+	})
+	return err
 }
 
 type digester interface {

--- a/internal/gopack/run_test.go
+++ b/internal/gopack/run_test.go
@@ -15,9 +15,18 @@
 package gopack
 
 import (
+	"archive/tar"
 	"context"
+	"io"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/ryanfowler/gopack/internal/types"
+
+	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/random"
 )
 
 func TestRunRejectsUnsupportedDaemonBeforeOtherWork(t *testing.T) {
@@ -43,5 +52,72 @@ func TestRunRejectsUnsupportedPlatformBeforeOtherWork(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), `unsupported platform "linux/ad64"`) {
 		t.Fatalf("Run() error = %q, want unsupported platform error", err)
+	}
+}
+
+func TestRunRejectsUnsupportedOutputBeforeOtherWork(t *testing.T) {
+	_, err := Run(context.Background(),
+		WithOutput("docker:./image.tar"),
+		WithMainPath("/path/that/does/not/exist"),
+	)
+	if err == nil {
+		t.Fatal("Run() error = nil, want unsupported output error")
+	}
+	if !strings.Contains(err.Error(), `unsupported output "docker:./image.tar"`) {
+		t.Fatalf("Run() error = %q, want unsupported output error", err)
+	}
+}
+
+func TestRunRejectsOutputWithDaemonLoadBeforeOtherWork(t *testing.T) {
+	_, err := Run(context.Background(),
+		WithOutput("oci:./image.tar"),
+		WithDaemon("docker"),
+		WithMainPath("/path/that/does/not/exist"),
+	)
+	if err == nil {
+		t.Fatal("Run() error = nil, want conflicting destination error")
+	}
+	if !strings.Contains(err.Error(), "cannot use output with daemon load") {
+		t.Fatalf("Run() error = %q, want conflicting destination error", err)
+	}
+}
+
+func TestWriteOCIArchive(t *testing.T) {
+	img, err := random.Image(1024, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	path := filepath.Join(t.TempDir(), "image.tar")
+	imgs := map[types.Platform]v1.Image{
+		types.ParsePlatform("linux/amd64"): img,
+	}
+	if err := writeOCIArchive(path, imgs); err != nil {
+		t.Fatal(err)
+	}
+
+	f, err := os.Open(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer f.Close()
+
+	seen := map[string]bool{}
+	tr := tar.NewReader(f)
+	for {
+		hdr, err := tr.Next()
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			t.Fatal(err)
+		}
+		seen[hdr.Name] = true
+	}
+
+	for _, name := range []string{"oci-layout", "index.json"} {
+		if !seen[name] {
+			t.Fatalf("OCI archive missing %s", name)
+		}
 	}
 }

--- a/internal/types/platform_test.go
+++ b/internal/types/platform_test.go
@@ -38,6 +38,12 @@ func TestPlatform(t *testing.T) {
 			isSupported: true,
 		},
 		{
+			name:        "should parse standard arm64 platform",
+			input:       "linux/arm64",
+			expOut:      Platform{os: "linux", arch: "arm64"},
+			isSupported: true,
+		},
+		{
 			name:        "should parse platform with colon variant",
 			input:       "linux/amd64:v4",
 			expOut:      Platform{os: "linux", arch: "amd64", variant: "v4"},


### PR DESCRIPTION
## Summary
- Added `gopack publish`, `gopack build`, and `gopack load` while keeping `gopack run` compatible.
- Added strict daemon handling for local loads and support for `--load` plus `--daemon docker`.
- Added OCI archive output support via `--output oci:<path>` and updated platform parsing coverage for standard strings like `linux/amd64`, `linux/arm64`, and `linux/arm/v7`.
- Updated README examples to match the new command structure.

## Testing
- `go test ./...`
- `staticcheck ./...`
- Verified command help for `run` and `load` reflects the new flags and defaults.