### PR TITLE
Use config platform for single-manifest base images

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -75,6 +75,8 @@ go.opentelemetry.io/otel/sdk/metric v1.36.0/go.mod h1:qTNOhFDfKRwX0yXOqJYegL5WRa
 go.opentelemetry.io/otel/trace v1.41.0 h1:Vbk2co6bhj8L59ZJ6/xFTskY+tGAbOnCtQGVVa9TIN0=
 go.opentelemetry.io/otel/trace v1.41.0/go.mod h1:U1NU4ULCoxeDKc09yCWdWe+3QoyweJcISEVa1RBzOis=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=
+golang.org/x/mod v0.36.0 h1:JJjpVx6myfUsUdAzZuOSTTmRE0PfZeNWzzvKrP7amb4=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/oauth2 v0.36.0 h1:peZ/1z27fi9hUOFCAZaHyrpWG5lwe0RJEEEeH0ThlIs=
 golang.org/x/oauth2 v0.36.0/go.mod h1:YDBUJMTkDnJS+A4BP4eZBjCqtokkg1hODuPjwiGPO7Q=
 golang.org/x/sync v0.21.0 h1:HLII4xRRTtCRkxYp4HNFF0Js/Og6q2i++KXbg0gHCwM=
@@ -83,6 +85,8 @@ golang.org/x/sys v0.46.0 h1:noSf2Fq6F8DBgS+LysIkx7rIExoNHJsxOAtPp4rthXw=
 golang.org/x/sys v0.46.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=
 golang.org/x/term v0.44.0 h1:0rLvDRCtNj0gZkyIXhCyOb2OAzEhLVqc4B+hrsBhrmc=
 golang.org/x/term v0.44.0/go.mod h1:7ze4MdzUzLXpSAoFP1H0bOI9aXDqveSvatT5vKcFh2Y=
+golang.org/x/tools v0.45.0 h1:18qN3FAooORvApf5XjCXgsuayZOEtXf6JK18I3+ONa8=
+golang.org/x/tools v0.45.0/go.mod h1:LuUGqqaXcXMEFEruIVJVm5mgDD8vww/z/SR1gQ4uE/0=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
 gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/internal/gopack/run.go
+++ b/internal/gopack/run.go
@@ -418,13 +418,17 @@ func matchImages(platforms []types.Platform, desc *remote.Descriptor) (map[types
 	out := make(map[types.Platform]v1.Image, len(platforms))
 
 	if desc.MediaType.IsImage() {
+		img, err := desc.Image()
+		if err != nil {
+			return nil, err
+		}
+		config, err := img.ConfigFile()
+		if err != nil {
+			return nil, err
+		}
 		for _, platform := range platforms {
-			if !platformsEqual(platform, desc.Platform) {
+			if !platformsEqual(platform, config.Platform()) {
 				return nil, fmt.Errorf("base image: platform %s: %w", platform, ErrNoMatchingImage)
-			}
-			img, err := desc.Image()
-			if err != nil {
-				return nil, err
 			}
 			out[platform] = img
 		}

--- a/internal/gopack/run_test.go
+++ b/internal/gopack/run_test.go
@@ -17,7 +17,11 @@ package gopack
 import (
 	"archive/tar"
 	"context"
+	"errors"
 	"io"
+	"log"
+	"net/http/httptest"
+	"net/url"
 	"os"
 	"path/filepath"
 	"strings"
@@ -25,8 +29,12 @@ import (
 
 	"github.com/ryanfowler/gopack/internal/types"
 
+	"github.com/google/go-containerregistry/pkg/name"
+	"github.com/google/go-containerregistry/pkg/registry"
 	v1 "github.com/google/go-containerregistry/pkg/v1"
+	"github.com/google/go-containerregistry/pkg/v1/mutate"
 	"github.com/google/go-containerregistry/pkg/v1/random"
+	"github.com/google/go-containerregistry/pkg/v1/remote"
 )
 
 func TestRunRejectsUnsupportedDaemonBeforeOtherWork(t *testing.T) {
@@ -82,6 +90,33 @@ func TestRunRejectsOutputWithDaemonLoadBeforeOtherWork(t *testing.T) {
 	}
 }
 
+func TestMatchImagesUsesConfigPlatformForImageManifest(t *testing.T) {
+	desc := pushImageManifest(t, imageWithPlatform(t, types.ParsePlatform("linux/amd64")))
+	if desc.Platform != nil {
+		t.Fatalf("test setup: descriptor platform = %#v, want nil", desc.Platform)
+	}
+
+	imgs, err := matchImages([]types.Platform{types.ParsePlatform("linux/amd64")}, desc)
+	if err != nil {
+		t.Fatalf("matchImages() error = %v", err)
+	}
+	if len(imgs) != 1 {
+		t.Fatalf("matchImages() returned %d images, want 1", len(imgs))
+	}
+}
+
+func TestMatchImagesRejectsImageManifestConfigPlatformMismatch(t *testing.T) {
+	desc := pushImageManifest(t, imageWithPlatform(t, types.ParsePlatform("linux/arm64")))
+
+	_, err := matchImages([]types.Platform{types.ParsePlatform("linux/amd64")}, desc)
+	if err == nil {
+		t.Fatal("matchImages() error = nil, want no matching image error")
+	}
+	if !errors.Is(err, ErrNoMatchingImage) {
+		t.Fatalf("matchImages() error = %v, want %v", err, ErrNoMatchingImage)
+	}
+}
+
 func TestWriteOCIArchive(t *testing.T) {
 	img, err := random.Image(1024, 1)
 	if err != nil {
@@ -120,4 +155,51 @@ func TestWriteOCIArchive(t *testing.T) {
 			t.Fatalf("OCI archive missing %s", name)
 		}
 	}
+}
+
+func imageWithPlatform(t *testing.T, platform types.Platform) v1.Image {
+	t.Helper()
+
+	img, err := random.Image(1024, 1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	config, err := img.ConfigFile()
+	if err != nil {
+		t.Fatal(err)
+	}
+	config = config.DeepCopy()
+	config.OS = platform.OS()
+	config.Architecture = platform.Arch()
+	config.Variant = strings.TrimPrefix(platform.Variant(), "v")
+
+	img, err = mutate.ConfigFile(img, config)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return img
+}
+
+func pushImageManifest(t *testing.T, img v1.Image) *remote.Descriptor {
+	t.Helper()
+
+	server := httptest.NewServer(registry.New(registry.Logger(log.New(io.Discard, "", 0))))
+	t.Cleanup(server.Close)
+
+	u, err := url.Parse(server.URL)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ref, err := name.NewTag(u.Host+"/base:latest", name.Insecure)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := remote.Write(ref, img); err != nil {
+		t.Fatal(err)
+	}
+	desc, err := remote.Get(ref)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return desc
 }


### PR DESCRIPTION
## Summary
- Read the image config before matching single-manifest base images
- Validate platform compatibility against the config platform instead of the descriptor platform
- Add tests covering matching and mismatched config platforms for image manifests

## Testing
- Not run (not requested)