### PR TITLE
Normalize Go target architecture env handling

### DIFF
--- a/internal/golang/golang.go
+++ b/internal/golang/golang.go
@@ -31,6 +31,18 @@ type GoBuilder struct {
 	opts options
 }
 
+var goArchTuningEnv = []string{
+	"GO386",
+	"GOAMD64",
+	"GOARM",
+	"GOARM64",
+	"GOMIPS",
+	"GOMIPS64",
+	"GOPPC64",
+	"GORISCV64",
+	"GOWASM",
+}
+
 func New(options ...Option) *GoBuilder {
 	opts := defaultOptions()
 	for _, o := range options {
@@ -82,27 +94,10 @@ func (b *GoBuilder) env(platform types.Platform) []string {
 	}
 	envMap["GOOS"] = platform.OS()
 	envMap["GOARCH"] = platform.Arch()
+	setTargetArchEnv(envMap, platform)
 	envMap["CGO_ENABLED"] = "0"
 	if b.opts.cgoEnabled {
 		envMap["CGO_ENABLED"] = "1"
-	}
-
-	variantStr := strings.TrimPrefix(platform.Variant(), "v")
-	if variantStr != "" {
-		if variant, err := strconv.Atoi(variantStr); err == nil {
-			switch platform.Arch() {
-			case "arm":
-				// https://github.com/golang/go/wiki/MinimumRequirements#arm
-				if variant >= 5 && variant <= 7 {
-					envMap["GOARM"] = variantStr
-				}
-			case "amd64":
-				// https://github.com/golang/go/wiki/MinimumRequirements#amd64
-				if variant >= 1 && variant <= 4 {
-					envMap["GOAMD64"] = "v" + variantStr
-				}
-			}
-		}
 	}
 
 	out := make([]string, 0, len(envMap))
@@ -111,4 +106,39 @@ func (b *GoBuilder) env(platform types.Platform) []string {
 	}
 	sort.Strings(out)
 	return out
+}
+
+func setTargetArchEnv(envMap map[string]string, platform types.Platform) {
+	for _, key := range goArchTuningEnv {
+		delete(envMap, key)
+	}
+
+	variant, hasVariant := variantNumber(platform)
+
+	switch platform.Arch() {
+	case "386":
+		envMap["GO386"] = "sse2"
+	case "amd64":
+		envMap["GOAMD64"] = "v1"
+		if hasVariant && variant >= 1 && variant <= 4 {
+			envMap["GOAMD64"] = "v" + strconv.Itoa(variant)
+		}
+	case "arm":
+		envMap["GOARM"] = "7"
+		if hasVariant && variant >= 5 && variant <= 7 {
+			envMap["GOARM"] = strconv.Itoa(variant)
+		}
+	case "arm64":
+		envMap["GOARM64"] = "v8.0"
+	}
+}
+
+func variantNumber(platform types.Platform) (int, bool) {
+	variantStr := strings.TrimPrefix(platform.Variant(), "v")
+	if variantStr != "" {
+		if variant, err := strconv.Atoi(variantStr); err == nil {
+			return variant, true
+		}
+	}
+	return 0, false
 }

--- a/internal/golang/golang_test.go
+++ b/internal/golang/golang_test.go
@@ -111,3 +111,73 @@ func TestEnvVariants(t *testing.T) {
 		})
 	}
 }
+
+func TestEnvClearsHostArchitectureTuning(t *testing.T) {
+	hostTuning := map[string]string{
+		"GO386":     "softfloat",
+		"GOAMD64":   "v4",
+		"GOARM":     "5,softfloat",
+		"GOARM64":   "v9.5,crypto",
+		"GOMIPS":    "softfloat",
+		"GOMIPS64":  "softfloat",
+		"GOPPC64":   "power10",
+		"GORISCV64": "rva23u64",
+		"GOWASM":    "satconv,signext",
+	}
+	for key, value := range hostTuning {
+		t.Setenv(key, value)
+	}
+
+	tests := []struct {
+		platform string
+		want     map[string]string
+	}{
+		{
+			platform: "linux/386",
+			want:     map[string]string{"GO386": "sse2"},
+		},
+		{
+			platform: "linux/amd64",
+			want:     map[string]string{"GOAMD64": "v1"},
+		},
+		{
+			platform: "linux/amd64/v3",
+			want:     map[string]string{"GOAMD64": "v3"},
+		},
+		{
+			platform: "linux/arm",
+			want:     map[string]string{"GOARM": "7"},
+		},
+		{
+			platform: "linux/arm/v5",
+			want:     map[string]string{"GOARM": "5"},
+		},
+		{
+			platform: "linux/arm64",
+			want:     map[string]string{"GOARM64": "v8.0"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.platform, func(t *testing.T) {
+			b := New()
+			platform := types.ParsePlatform(tt.platform)
+			env := b.env(platform)
+			m := envToMap(t, env)
+
+			for key, want := range tt.want {
+				if got := m[key]; got != want {
+					t.Errorf("%s = %q, want %q", key, got, want)
+				}
+			}
+			for key, poisoned := range hostTuning {
+				if _, ok := tt.want[key]; ok {
+					continue
+				}
+				if got, ok := m[key]; ok {
+					t.Errorf("%s leaked as %q from host value %q", key, got, poisoned)
+				}
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary
- Clear host-specific Go architecture tuning variables before building target env
- Set explicit defaults for `GO386`, `GOAMD64`, `GOARM`, and `GOARM64` by target platform
- Add coverage to verify host tuning values do not leak into cross-build envs

## Testing
- Unit tests added for target architecture env selection and host-variable cleanup